### PR TITLE
Add support for Ed25519 certificates

### DIFF
--- a/src/certy/certificate_revocation_list.py
+++ b/src/certy/certificate_revocation_list.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-import datetime
+from datetime import datetime, timedelta, timezone
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
@@ -31,8 +31,8 @@ class CertificateRevocationList(object):
         self,
         issuer: Credential | None = None,
         revoked_certificates: list[Credential] | None = None,
-        this_update: datetime.datetime | None = None,
-        next_update: datetime.datetime | None = None,
+        this_update: datetime | None = None,
+        next_update: datetime | None = None,
     ):
         self._issuer = issuer
         self._revoked_certificates = revoked_certificates or []
@@ -62,26 +62,26 @@ class CertificateRevocationList(object):
         self._issuer = issuer
         return self
 
-    def this_update(self, this_update: datetime.datetime) -> CertificateRevocationList:
+    def this_update(self, this_update: datetime) -> CertificateRevocationList:
         """Set the ``thisUpdate`` field of the CRL.
 
         If not called, the ``thisUpdate`` field will be set to the current time.
 
         :param this_update: The ``thisUpdate`` field of the CRL.
-        :type this_update: datetime.datetime
+        :type this_update: datetime
         :return: self
         :rtype: CertificateRevocationList
         """
         self._this_update = this_update
         return self
 
-    def next_update(self, next_update: datetime.datetime) -> CertificateRevocationList:
+    def next_update(self, next_update: datetime) -> CertificateRevocationList:
         """Set the ``nextUpdate`` field of the CRL.
 
         If not called, the ``nextUpdate`` field will be set to ``thisUpdate`` plus 7 days.
 
         :param next_update: The nextUpdate field of the CRL.
-        :type next_update: datetime.datetime
+        :type next_update: datetime
         :return: self
         :rtype: CertificateRevocationList
         """
@@ -128,11 +128,11 @@ class CertificateRevocationList(object):
         # Ensure that the issuer has a key pair.
         self._issuer._ensure_generated()
 
-        effective_revocation_time = datetime.datetime.utcnow()
+        effective_revocation_time = datetime.now(timezone.utc)
         if self._this_update:
             effective_revocation_time = self._this_update
 
-        effective_expiry_time = effective_revocation_time + datetime.timedelta(days=7)
+        effective_expiry_time = effective_revocation_time + timedelta(days=7)
         if self._next_update:
             effective_expiry_time = self._next_update
 

--- a/tests/test_certificate_revocation_list.py
+++ b/tests/test_certificate_revocation_list.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 from cryptography import x509
 
@@ -43,14 +43,14 @@ def test_this_update(ca):
     crl = CertificateRevocationList().issuer(ca).this_update(datetime(2023, 10, 31, 9, 0))
     got = x509.load_der_x509_crl(crl.get_as_der())
     assert got is not None
-    assert got.last_update == datetime(2023, 10, 31, 9, 0)
+    assert got.last_update_utc == datetime(2023, 10, 31, 9, 0, tzinfo=timezone.utc)
 
 
 def test_next_update(ca):
-    crl = CertificateRevocationList().issuer(ca).next_update(datetime(2023, 10, 31, 9, 0))
+    crl = CertificateRevocationList().issuer(ca).this_update(datetime(2023, 10, 31, 9, 0)).next_update(datetime(2024, 10, 31, 9, 0))
     got = x509.load_der_x509_crl(crl.get_as_der())
     assert got is not None
-    assert got.next_update == datetime(2023, 10, 31, 9, 0)
+    assert got.next_update_utc == datetime(2024, 10, 31, 9, 0, tzinfo=timezone.utc)
 
 
 def test_issuer(ca):

--- a/tests/test_credential_errors.py
+++ b/tests/test_credential_errors.py
@@ -38,6 +38,8 @@ def test_invalid_key_size():
         Credential().subject("CN=joe").key_type(KeyType.RSA).key_size(123)
     with pytest.raises(ValueError):
         Credential().subject("CN=joe").key_size("not a valid key size")
+    with pytest.raises(ValueError):
+        Credential().subject("CN=joe").key_type(KeyType.ED25519).key_size(123)
 
 
 def test_invalid_ca():


### PR DESCRIPTION
This change adds support for generating Ed25519 certificates.

Updated for deprecations:

* Replaced outdated `datetime` calls with timezone-aware UTC versions.
* Updated unit tests for `nnn_utc` timezone-aware `datetime` fields.

Running tests requires `cryptography` version [42.0.0](https://cryptography.io/en/latest/changelog) or later.

Fixes issue #2
